### PR TITLE
[Patch] 32 bit counter limits seq length - switched to `ContSamps` mode + `stop_by_underrun()`

### DIFF
--- a/niexpctrl_backend/src/device.rs
+++ b/niexpctrl_backend/src/device.rs
@@ -326,16 +326,17 @@ pub trait StreamableDevice: BaseDevice + Sync + Send {
         // Now need to wait for the final sample chunk to be generated out by the card before stopping the task.
         // In the mean time, we can calculate the initial chunk for the next repetition in the case we are on repeat.
         if !calc_next {
-            stream_bundle.ni_task.wait_until_done(stream_bundle.buf_write_timeout.clone())?;
-            stream_bundle.ni_task.stop()?;
+            stream_bundle.ni_task.stop_by_underrun(stream_bundle.buf_write_timeout.clone())?;
         } else {
+            // Calculate the sample chunk
             stream_bundle.counter.reset();
             let (start_pos, end_pos) = stream_bundle.counter.tick_next().unwrap();
             let samp_arr = self.calc_signal_nsamps(start_pos, end_pos, end_pos - start_pos, true, false);
 
-            stream_bundle.ni_task.wait_until_done(stream_bundle.buf_write_timeout.clone())?;
-            stream_bundle.ni_task.stop()?;
+            // Handle stop:
+            stream_bundle.ni_task.stop_by_underrun(stream_bundle.buf_write_timeout.clone())?;
 
+            // Write the sample chunk in
             stream_bundle.write_buf(samp_arr)?;
         }
         Ok(())

--- a/niexpctrl_backend/src/nidaqmx.rs
+++ b/niexpctrl_backend/src/nidaqmx.rs
@@ -83,6 +83,7 @@ pub type TaskHandle = *mut libc::c_void;
 pub const DAQMX_VAL_RISING: CInt32 = 10280;
 pub const DAQMX_VAL_VOLTS: CInt32 = 10348;
 pub const DAQMX_VAL_FINITESAMPS: CInt32 = 10178;
+pub const DAQMX_VAL_CONTSAMPS: CInt32 = 10123;
 pub const DAQMX_VAL_DONOTALLOWREGEN: CInt32 = 10158;
 pub const DAQMX_VAL_GROUPBYCHANNEL: CBool32 = 0;
 pub const DAQMX_VAL_GROUPBYSCANNUMBER: CBool32 = 1;
@@ -93,6 +94,8 @@ pub const DAQMX_VAL_STARTTRIGGER: CInt32 = 12491;
 pub const DAQMX_VAL_SAMPLECLOCK: CInt32 = 12487;
 pub const DAQMX_VAL_10MHZREFCLOCK: CInt32 = 12536;
 pub const DAQMX_VAL_DO_NOT_INVERT_POLARITY: CInt32 = 0;
+
+pub const BUFFER_UNDERRUN_ERROR_CODE: CInt32 = -200290;
 
 #[link(name = "NIDAQmx")]
 extern "C" {
@@ -230,7 +233,11 @@ impl From<NulError> for DAQmxError {
 /// * There's a failure in opening or writing to the "nidaqmx_error.logs" file.
 pub fn daqmx_call<F: FnOnce() -> CInt32>(func: F) -> Result<(), DAQmxError> {
     let status_code = func();
-    if status_code >= 0 {
+    interpret_daqmx_status_code(status_code)
+}
+
+pub fn interpret_daqmx_status_code(code: CInt32) -> Result<(), DAQmxError> {
+    if code >= 0 {
         Ok(())
     } else {
         let mut err_buff = [0i8; 2048];
@@ -357,6 +364,41 @@ impl NiTask {
         };
         daqmx_call(|| unsafe { DAQmxWaitUntilTaskDone(self.handle, timeout) })
     }
+    /// A specialized version of `Self::wait_until_done` which ignores buffer underrun error.
+    /// All other types of runtime errors will still result in `DAQmxError` return.
+    /// Use this method when relying on buffer underrun as the stop mechanism.
+    pub fn wait_until_done_ignore_underrun(&self, timeout: Option<f64>) -> Result<(), DAQmxError> {
+        let timeout = match timeout {
+            Some(timeout) => timeout as CFloat64,
+            None => DAQMX_VAL_WAITINFINITELY,
+        };
+        let status_code = unsafe { DAQmxWaitUntilTaskDone(self.handle, timeout) };
+        if status_code == BUFFER_UNDERRUN_ERROR_CODE {
+            // Ignore underrun error
+            Ok(())
+        } else {
+            // Properly handle any other status code to catch other types of runtime errors
+            // (write/wait timeout, lost PLL ref signal, output voltage limit exceeded...)
+            interpret_daqmx_status_code(status_code)
+        }
+    }
+    /// Special version of `Self::stop()` which relies on an intentional buffer underrun
+    /// as a way of deterministic generation stop.
+    /// This function only ignores the underrun error and will still return `DAQmxError`
+    /// if any other kind of runtime error occurs.
+    pub fn stop_by_underrun(&self, timeout: Option<f64>) -> Result<(), DAQmxError> {
+        // - wait until all the samples are played out from the buffer
+        //   and NI task stops due to the intentional underrun
+        //   (This call only ignores the underrun error and still returns DAQmxError if any other type of error occurs)
+        self.wait_until_done_ignore_underrun(timeout)?;
+
+        // - dispose of the intentional underrun error by calling stop() once and dumping the return
+        // (if there were any other error type, the previous call would have force-returned already)
+        let _ = self.stop();
+
+        // - the second stop() call should return without any errors
+        self.stop()
+    }
     pub fn disallow_regen(&self) -> Result<(), DAQmxError> {
         daqmx_call(|| unsafe { DAQmxSetWriteRegenMode(self.handle, DAQMX_VAL_DONOTALLOWREGEN) })
     }
@@ -369,7 +411,7 @@ impl NiTask {
                 src_cstring.as_ptr(),
                 samp_rate as CFloat64,
                 DAQMX_VAL_RISING,
-                DAQMX_VAL_FINITESAMPS,
+                DAQMX_VAL_CONTSAMPS,
                 seq_len as CUint64,
             )
         })


### PR DESCRIPTION
Fix to the issue that NI 6535 DO cards do not accept total sequence length parameter greater than `2^32 - 1` samples. (Other card type, at least 6738 and 6363, don't have this limit - most likely they have 64-bit onboard counters).

Proposed solution is somewhat hack-ish, but is quite simple and seems to work:

- In `DAQmxCfgSampClkTiming()` set mode to be `DAQmx_Val_ContSamps` - the task is not asked to automatically stop by itself;
- Calculate and write sample chunks to the buffer as normal;
- For the sequence end, call `DAQmxWaitUntilTaskDone` to wait until all samples are played out and, well, the task fails due to the buffer underrun;
- Absorb the underrun error and return as normally. Importantly, one should still propagate any other types of errors which could have occured during playing the final chunk (for example, PLL failure, overvoltage, or write timeout due to missing external sample clock).

After-run output behavior is the same as usual - channels keep the last value.

### Possible concerns

Relying on intentional failure doesn't seem to be very clean. 

Empirically tested that preforming about 10,000 cycles of such failure-recovery in a single run does not lead to any noticeable issues. But that behavior is not officially documented and may change with future versions of NI DAQmx driver. 

Underrun error "catching" is based on matching to a specific status code. If the code value changes in future, this catch will break as well.


